### PR TITLE
fix proxy setting usage

### DIFF
--- a/src/main/java/hudson/plugins/humbug/Humbug.java
+++ b/src/main/java/hudson/plugins/humbug/Humbug.java
@@ -61,7 +61,7 @@ public class Humbug {
         return this.email;
     }
 
-    public String post(String method, NameValuePair[] parameters) {
+    public String post(String method, NameValuePair[] parameters) throws IOException {
         PostMethod post = new PostMethod(getApiEndpoint() + method);
         post.setRequestHeader("Content-Type", post.FORM_URL_ENCODED_CONTENT_TYPE);
         String auth_info = this.getEmail() + ":" + this.getApiKey();
@@ -83,8 +83,6 @@ public class Humbug {
                                          "We sent:" + params);
             }
             return response;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         } finally {
             post.releaseConnection();
         }
@@ -112,7 +110,7 @@ public class Humbug {
 //        return true;
 //    }
 
-    public String sendStreamMessage(String stream, String subject, String message) {
+    public String sendStreamMessage(String stream, String subject, String message) throws IOException {
         NameValuePair[] body = {new NameValuePair("api-key", this.getApiKey()),
                                 new NameValuePair("email",   this.getEmail()),
                                 new NameValuePair("type",    "stream"),

--- a/src/main/java/hudson/plugins/humbug/HumbugNotifier.java
+++ b/src/main/java/hudson/plugins/humbug/HumbugNotifier.java
@@ -92,7 +92,14 @@ public class HumbugNotifier extends Notifier {
             message += "\n\n";
             message += changeString;
         }
-        humbug.sendStreamMessage(stream, build.getProject().getName(), message);
+        try {
+            humbug.sendStreamMessage(stream, build.getProject().getName(), message);
+        }
+        catch ( IOException ex ){
+            LOGGER.log(Level.SEVERE, "Error sending Zulip message. Project: '" + build.getProject().getName() +
+                    "' Message: '" + message + "'", ex);
+            // TODO: output some message to the build log here?
+        }
     }
 
     private void initialize()  {


### PR DESCRIPTION
This includes a fix to the usage of the Jenkins proxy settings as well as a fix to not throw an error directly into the build log and thus fail the build just because the zulip notification failed to publish correctly.
